### PR TITLE
Add kludge to deal with numpy deprecations

### DIFF
--- a/libs/simulator/devices/callback_i.c
+++ b/libs/simulator/devices/callback_i.c
@@ -223,6 +223,12 @@ static int deviceClassLinearize(device_ *r, int *linear)
 
 /*---------------------------------------------------------------------------*/
 
+static int deviceClassLoadVariable(variable_ *r, devicePrivate_ *p)
+{
+	r->G = 0.0;
+	return 0;
+}
+
 static int deviceClassLoad(device_ *r)
 {
 	devicePrivate_ *p;
@@ -240,6 +246,8 @@ static int deviceClassLoad(device_ *r)
 	p->In = 0.0;
 	p->Ieq = 0.0;
 	p->IeqCalc = 0.0;
+	ReturnErrIf(listExecute(p->variables,
+			(listExecute_)deviceClassLoadVariable, p));
 
 	/* Modified Nodal Analysis Stamp Current Source
 	 *	                     	  		+  /\ - + __  -

--- a/libs/simulator/devices/callback_v.c
+++ b/libs/simulator/devices/callback_v.c
@@ -216,6 +216,12 @@ static int deviceClassLinearize(device_ *r, int *linear)
 
 /*---------------------------------------------------------------------------*/
 
+static int deviceClassLoadVariable(variable_ *r, devicePrivate_ *p)
+{
+	r->R = 0.0;
+	return 0;
+}
+
 static int deviceClassLoad(device_ *r)
 {
 	devicePrivate_ *p;
@@ -233,6 +239,8 @@ static int deviceClassLoad(device_ *r)
 	p->Vn = 0.0;
 	p->Veq = 0.0;
 	p->VeqCalc = 0.0;
+	ReturnErrIf(listExecute(p->variables,
+			(listExecute_)deviceClassLoadVariable, p));
 
 	/* Modified Nodal Analysis Stamp Voltage Source
 	 *	                     	        +  /\  -

--- a/libs/simulator/devices/nonlinear_c.c
+++ b/libs/simulator/devices/nonlinear_c.c
@@ -302,6 +302,12 @@ static int deviceClassInitStep(device_ *r)
 
 /*---------------------------------------------------------------------------*/
 
+static int deviceClassLoadVariable(variable_ *r, devicePrivate_ *p)
+{
+	r->R = 0.0;
+	return 0;
+}
+
 static int deviceClassLoad(device_ *r)
 {
 	devicePrivate_ *p;
@@ -317,6 +323,8 @@ static int deviceClassLoad(device_ *r)
 	p->Cn = 0.0;
 	p->Ceq = 0.0;
 	p->CeqCalc = 0.0;
+	ReturnErrIf(listExecute(p->variables,
+			(listExecute_)deviceClassLoadVariable, p));
 
 	/* Modified Nodal Analysis Stamp (Open)
 	 *	                  	+      -

--- a/libs/simulator/devices/nonlinear_i.c
+++ b/libs/simulator/devices/nonlinear_i.c
@@ -245,6 +245,12 @@ static int deviceClassLinearize(device_ *r, int *linear)
 
 /*---------------------------------------------------------------------------*/
 
+static int deviceClassLoadVariable(variable_ *r, devicePrivate_ *p)
+{
+	r->G = 0.0;
+	return 0;
+}
+
 static int deviceClassLoad(device_ *r)
 {
 	devicePrivate_ *p;
@@ -261,6 +267,8 @@ static int deviceClassLoad(device_ *r)
 	p->In = 0.0;
 	p->Ieq = 0.0;
 	p->IeqCalc = 0.0;
+	ReturnErrIf(listExecute(p->variables,
+			(listExecute_)deviceClassLoadVariable, p));
 
 	/* Modified Nodal Analysis Stamp Current Source
 	 *	                     	       	+  /\ - + __  -

--- a/libs/simulator/devices/nonlinear_v.c
+++ b/libs/simulator/devices/nonlinear_v.c
@@ -213,6 +213,12 @@ static int deviceClassLinearize(device_ *r, int *linear)
 
 /*---------------------------------------------------------------------------*/
 
+static int deviceClassLoadVariable(variable_ *r, devicePrivate_ *p)
+{
+	r->R = 0.0;
+	return 0;
+}
+
 static int deviceClassLoad(device_ *r)
 {
 	devicePrivate_ *p;
@@ -229,6 +235,8 @@ static int deviceClassLoad(device_ *r)
 	p->Vn = 0.0;
 	p->Veq = 0.0;
 	p->VeqCalc = 0.0;
+	ReturnErrIf(listExecute(p->variables,
+			(listExecute_)deviceClassLoadVariable, p));
 
 	/* Modified Nodal Analysis Stamp Voltage Source
 	 *	                     	        +  /\  -

--- a/module/plot.py
+++ b/module/plot.py
@@ -167,12 +167,12 @@ class Plot(tk.Canvas):
         self.colours = ['red', 'navy', 'green', 'orange', 'purple',
                 'cyan', 'magenta',  'yellow', 'darkred']
 
-        if legend == None:
+        if legend is None:
             self.legend = []
         else:
             self.legend = legend
 
-        if data == None:
+        if data is None:
             self.data = []
         else:
             self.data = data
@@ -372,7 +372,7 @@ def plot(*lst):
 
     for circuit in lst:
 
-        if circuit.results == None:
+        if circuit.results is None:
             raise RuntimeError("Circuit %s has no results." % circuit.title)
 
         try:


### PR DESCRIPTION
I was just experimenting this morning and made a few changes to get `python3-eispice` to build and run the demo code:
```
import eispice
cct = eispice.Circuit("Capacitor Test")
cct.Vx = eispice.V(1, eispice.GND, 4,
  eispice.Pulse(4, 8, '10n', '2n', '3n', '5n', '20n'))
cct.Cx = eispice.C(1, eispice.GND, '10n')
cct.tran('0.5n', '100n')
eispice.plot(cct)
```
I thought it might be useful for others. Although I must say what I did is pretty kludgey, so do feel free to do it better if you prefer.

Update: I have also fixed a bug that prevented repeated solving from working when there were nonlinear sources.

This is what I was trying to do:
```
#!/usr/bin/env python3

import eispice

CONST_k = 1.3806503e-23 # Boltzmann's Constant (1/JK)
CONST_q = 1.60217646e-19 # Electron Charge (C)
CONST_TNOM = 25.
CONST_V_T = CONST_k * (CONST_TNOM + 273.15) / CONST_q # Thermal Voltage

class D(eispice.Subckt):
  def __init__(self, node_A, node_K, I_S = 1e-12, n = 1.):
    self.I_D = eispice.B(
      node_A,
      node_K,
      eispice.Current,
      f'{I_S:e}*(exp(v({str(node_A):s},{str(node_K):s})/{n*CONST_V_T:e})-1)'
    )

if __name__ == '__main__':
  circuit = eispice.Circuit()
  circuit.V1 = eispice.V(1, eispice.GND)
  circuit.D1 = D(1, eispice.GND)
  circuit.V1.DC = .6
  circuit.op()
  print('circuit.variables', circuit.variables)
  print('circuit.results', circuit.results)
  circuit.V1.DC = .7
  circuit.op()
  print('circuit.results', circuit.results)
```
The second solve was failing because of a missing initialization in the nonlinear current source code.

Basically when the device code (e.g. nonlinear current source) wants to update the MNA matrix (MNA = Modified Node Analysis), instead of overwriting a cell it always adds / subtracts something to the cell, that's because it doesn't know if another device might be manipulating the same cell, so it needs to be transparent in that case. Therefore, it always remembers what it last "wrote" to the cell and if it wants to "write" a new value to the cell, it adds the difference between new and old values.

What the extra initialization does is to zero the saved copy of what was last "written" to the cell -- since matrix was also zeroed.